### PR TITLE
Move collections dependency to non-dev deps

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start": "ts-node server"
   },
   "dependencies": {
+    "@types/collections": "^5.0.2",
     "@types/cors": "^2.8.8",
     "@types/knex": "^0.16.1",
     "@types/stopword": "^0.3.0",
@@ -28,7 +29,6 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@types/collections": "^5.0.2",
     "@types/express": "^4.17.8",
     "@types/node": "^14.14.2",
     "@typescript-eslint/eslint-plugin": "^4.6.1",


### PR DESCRIPTION
Tested with docker compose

Fixes the build/boot deyployment bug used as an example in #57 