### PR TITLE
rewrite irc message parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ backend/.env
 .vercel
 node_modules/
 package-lock.json
+
+/database

--- a/backend/irc/IrcMessageProcessor.ts
+++ b/backend/irc/IrcMessageProcessor.ts
@@ -105,7 +105,7 @@ class IrcMessageProcessor {
   }
 
   private processNotice(ircMessage: IrcMessage): void {
-    const param = ircMessage.params.slice(1).join(' ');
+    const param = ircMessage.params[1];
     if (param.includes('assword incorrect') || param.includes('is not registered')) {
       console.log('PASSWORD IS NOT CORRECT. NICK WILL BE CHANGED.');
       this.client.write(`JOIN ${this.joinConfig.channel}\r\n`);
@@ -151,14 +151,14 @@ class IrcMessageProcessor {
   }
 
   private async processNick(ircMessage: IrcMessage): Promise<void> {
-    const oldNick = ircMessage.prefix?.split('!')[0].slice(1);
+    const oldNick = ircMessage.prefix?.split('!')[0];
     const newNick = ircMessage.params[0];
     await DatabaseUserUtils.updateUser('KEEP', oldNick!, newNick);
     myEmitter.emit('join');
   }
 
   private async processJoin(ircMessage: IrcMessage): Promise<void> {
-    const nick = ircMessage.prefix && ircMessage.prefix.split('!')[0].slice(1);
+    const nick = ircMessage.prefix && ircMessage.prefix.split('!')[0];
     if (nick != this.joinConfig.user) {
       console.log(nick, nick!.slice(1), nick![0] === '@' || '%' || '+');
       nick!.match(/^[@|%|+]/)
@@ -169,7 +169,7 @@ class IrcMessageProcessor {
   }
 
   private async process353(ircMessage: IrcMessage): Promise<void> {
-    ircMessage.params.slice(3).forEach(async (name) => {
+    ircMessage.params[3].split(' ').forEach(async (name) => {
       name = name.replace(':', '').trim();
       if (name.length > 0) {
         // add second column to host the role to join with nick later
@@ -199,7 +199,7 @@ class IrcMessageProcessor {
     if (Date.now() - this.joinConfig.bufferTime.getTime() < 5000) return;
 
     const msg = ircMessage.params[1];
-    const nick = ircMessage.prefix && ircMessage.prefix.split('!')[0].slice(1);
+    const nick = ircMessage.prefix && ircMessage.prefix.split('!')[0];
     const server = ircMessage.params[0];
 
     // Process non bot messages
@@ -210,7 +210,7 @@ class IrcMessageProcessor {
       // Process bot messages
       // Process ducc stats
       if (msg.match(/Duck \w{6} scores in #/i) && nick === 'gonzobot') {
-        const duccMsg = ircMessage.params.slice(1).join(' ');
+        const duccMsg = ircMessage.params[1];
         const splitMsgByBullet = duccMsg.split('\u2022');
         // fix the first split by removing the 'Duck ... scores in #channel'
         const correctFirstScore = splitMsgByBullet[0].split(':');

--- a/backend/irc/utils/db/InitDatabase.ts
+++ b/backend/irc/utils/db/InitDatabase.ts
@@ -25,7 +25,7 @@ class InitDatabase {
         return knex.schema.createTable('last_messages', function (table) {
           table.string('user');
           table.string('server');
-          table.string('message');
+          table.string('message', 512);
           table.dateTime('dateCreated').defaultTo(knex.fn.now());
         });
       }

--- a/backend/irc/utils/db/docker-entrypoint-initdb.d/lmrdashboard.schema.sql
+++ b/backend/irc/utils/db/docker-entrypoint-initdb.d/lmrdashboard.schema.sql
@@ -73,7 +73,7 @@ DROP TABLE IF EXISTS `last_messages`;
 CREATE TABLE `last_messages` (
   `user` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `server` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `message` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `message` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `dateCreated` datetime NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/backend/tests/IrcMessageProcessor.test.ts
+++ b/backend/tests/IrcMessageProcessor.test.ts
@@ -2,12 +2,12 @@ import { JoinConfig } from '../irc/ircconnection';
 import { IrcMessage, IrcMessageProcessor } from '../irc/IrcMessageProcessor';
 
 const mockIrcMessage = {
-  prefix: ':Nick!Nick@snoonet.org/user/Nick',
+  prefix: 'Nick!Nick@snoonet.org/user/Nick',
   command: 'PRIVMSG',
-  params: ['#channel', ':myMessage'],
+  params: ['#channel', 'my message with multiple words'],
 };
 
-const mockLine = ':Nick!Nick@snoonet.org/user/Nick PRIVMSG #channel :myMessage';
+const mockLine = ':Nick!Nick@snoonet.org/user/Nick PRIVMSG #channel :my message with multiple words';
 
 const mockJoinConfig: JoinConfig = {
   channel: '#channel',


### PR DESCRIPTION
Rewrite the IRC message parsing and fix problems in related functions as discovered in #74.

## TODOs
- [x] Rewrite Parser
- [x] parsePrivMsg
  - [x] Remove the .join()s
  - [x] Increase Message size limit to 512

closes #74 