### PR TITLE
fixed part/quit bug not parsing correctly

### DIFF
--- a/backend/irc/IrcMessageProcessor.ts
+++ b/backend/irc/IrcMessageProcessor.ts
@@ -160,7 +160,6 @@ class IrcMessageProcessor {
   private async processJoin(ircMessage: IrcMessage): Promise<void> {
     const nick = ircMessage.prefix && ircMessage.prefix.split('!')[0];
     if (nick != this.joinConfig.user) {
-      console.log(nick, nick!.slice(1), nick![0] === '@' || '%' || '+');
       nick!.match(/^[@|%|+]/)
         ? await DatabaseUserUtils.addUser(nick!.slice(1), nick![0])
         : await DatabaseUserUtils.addUser(nick!, null);
@@ -170,7 +169,6 @@ class IrcMessageProcessor {
 
   private async process353(ircMessage: IrcMessage): Promise<void> {
     ircMessage.params[3].split(' ').forEach(async (name) => {
-      name = name.replace(':', '').trim();
       if (name.length > 0) {
         // add second column to host the role to join with nick later
         name.match(/^[@|%|+]/)
@@ -182,7 +180,7 @@ class IrcMessageProcessor {
   }
 
   private async processPartAndQuit(ircMessage: IrcMessage) {
-    const nick = ircMessage.prefix && ircMessage.prefix.split('!')[0].slice(1);
+    const nick = ircMessage.prefix && ircMessage.prefix.split('!')[0];
     await DatabaseUserUtils.deleteUser(nick!);
     myEmitter.emit('part');
     console.log('RUNNING PARTANDQUIT');


### PR DESCRIPTION
```
:coke!coke@user/Tyler JOIN :#linuxmasterrace
coke oke %
ATTEMPTING TO ADD NEW USER coke
coke has come online.
:llh!coke@user/Tyler QUIT :Ping timeout: 120 seconds
User lh has parted.
RUNNING PARTANDQUIT
:coke!coke@user/Tyler NICK :llh

/lmrdashboard/backend/node_modules/mysql/lib/protocol/sequences/Sequence.js:47
  var err  = new Error(code + ': ' + packet.message);
             ^
Error: ER_DUP_ENTRY: Duplicate entry 'llh' for key 'online_users_user_unique'
    at Query.Sequence._packetToError (/lmrdashboard/backend/node_modules/mysql/lib/protocol/sequences/Sequence.js:47:14)
    at Query.ErrorPacket (/lmrdashboard/backend/node_modules/mysql/lib/protocol/sequences/Query.js:79:18)
```

This issue derived from the parser being changed but using old logic which assumed a colon ':' was still in the prefix. This has been adjusted.