### PR TITLE
Remove more stopwords

### DIFF
--- a/backend/Sender.ts
+++ b/backend/Sender.ts
@@ -1,5 +1,6 @@
 import { Response } from 'express-serve-static-core';
 import sw from 'stopword';
+import stopwordsEn from 'stopwords-en';
 import { DatabaseMessageUtils, IMessage } from './database/Messages';
 import { DatabaseUserUtils } from './database/Users';
 import { DatabaseDuccUtils } from './database/DuccScores';
@@ -51,10 +52,16 @@ class Sender {
 
     for (const message of messages) {
       const messageText: string = message.message.toLowerCase();
-      const words = sw.removeStopwords(messageText.split(/\s+/));
-      for (let word of words) {
-        // strip any non alpha chars to prevent odd render on screen
-        word = word.replace(/[^a-zA-Z0-9 ]/g, '').trim();
+
+      const splitAndCleanedWords: string[] = messageText.split(/\s+/)
+        .map((word: string) =>
+          word.replace(/[^a-zA-Z0-9 ]/g, '').trim()
+        );
+
+      // More stop word sources are necessary to filter out all
+      const words = sw.removeStopwords(splitAndCleanedWords, [...sw.en, ...stopwordsEn]);
+
+      for (const word of words) {
         if (word && !word.match(/^[0-9]*$/)) {
           if (!wordCounts.has(word)) wordCounts.set(word, 1);
           else wordCounts.set(word, wordCounts.get(word)! + 1);

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "net": "^1.0.2",
     "readline": "^1.3.0",
     "stopword": "^1.0.3",
+    "stopwords-en": "^0.3.0",
     "tls": "^0.0.1",
     "ts-node": "^9.0.0",
     "typeorm": "^0.2.28",

--- a/backend/tests/Sender.test.ts
+++ b/backend/tests/Sender.test.ts
@@ -3,6 +3,9 @@ import last_messages from './resources/mock_db_data/last_messages.json';
 import { DatabaseMessageUtils } from '../database/Messages';
 import { Sender } from '../Sender';
 import knex from '../database/dbConn';
+import sw from 'stopword';
+import stopwordsEn from 'stopwords-en';
+
 const tracker = require('mock-knex').getTracker();
 
 let LAST_MESSAGES: { user: string; server: string; message: string; dateCreated: Date | string }[] = [];
@@ -50,18 +53,28 @@ describe('test Sender with mocked database response', () => {
 
     const sortedWordCounts = await Sender.getTopWords();
     const expected: Map<string, number> = new Map();
+    // Stop words are removed
     expected.set('linux', 3);
-    expected.set('good', 2);
     expected.set('windows', 1);
     expected.set('bad', 1);
-    expected.set('dont', 1);
-    expected.set('need', 1);
-    expected.set('it', 1);
-    expected.set('thanks', 1);
-    expected.set('im', 1);
-    expected.set('best', 1);
     expected.set('love', 1);
 
     expect(sortedWordCounts).toEqual(expected);
+  });
+
+  test('sw removeStopWords filters out some stop words', async () => {
+    // sw's stopword list is not exhaustive
+    const textWithStopWords = 'im is a text with stopwords its it is don\'t be not no yes so this or that'.split(/\s+/);
+    const customStopwords = ['don\'t']
+    const textWithoutStopWords = sw.removeStopwords(textWithStopWords, [...sw.en, ...customStopwords]);
+    const expected = ['im', 'text', 'stopwords', 'its', 'not', 'no', 'yes', 'so']
+    expect(textWithoutStopWords).toEqual(expected);
+  });
+
+  test('sw removeStopWords with an additional stopwords source filters out all stop words', async () => {
+    const textWithStopWords = 'im is a text with stopwords its it is don\'t be not no yes so this or that'.split(/\s+/);
+    const textWithoutStopWords = sw.removeStopwords(textWithStopWords, [...sw.en, ...stopwordsEn]);
+    const expected = ['stopwords']
+    expect(textWithoutStopWords).toEqual(expected);
   });
 });

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -4575,6 +4575,11 @@ stopword@^1.0.3:
   resolved "https://registry.yarnpkg.com/stopword/-/stopword-1.0.3.tgz"
   integrity sha512-rkoAluafz+D0GmzGekXBnHmdZ5VeiqeloLBfoclrshdmuQpf5XgvIr+lJPftg3mH54Cc0LHHZIaJvA5Cj0E5jA==
 
+stopwords-en@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/stopwords-en/-/stopwords-en-0.3.0.tgz#ef1ffbd32e03cf2f9cbf226adcb80e27ec3fe0ff"
+  integrity sha1-7x/70y4Dzy+cvyJq3LgOJ+w/4P8=
+
 string-length@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.1.tgz"


### PR DESCRIPTION
Close #96 

`sw`'s list of stopwords was simply incomplete so now a second source is used, as well as punctuation needed to be stripped before the stopword removal.