### PR TITLE
Generate ducc stats weekly instead of daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ LMRD_IRC_PORT=6697
 LMRD_IRC_CHANNEL=#aboftytest
 LMRD_IRC_USER=<testusernick>
 LMRD_IRC_PASS=<password>
+LMRD_DUCC_TIME=09:00
+LMRD_DUCC_DAY=0
 ```
 
 #### Database

--- a/backend/Containerfile
+++ b/backend/Containerfile
@@ -17,7 +17,8 @@ ENV LMRD_IRC_CHANNEL "#linuxmasterrace" \
     LMRD_DB_NAME "lmrd" \
     LMRD_DB_USER \
     LMRD_DB_PASS \
-    LMRD_DUCC_TIME "09:00"
+    LMRD_DUCC_TIME "09:00" \
+    LMRD_DUCC_DAY "0"
 
 EXPOSE 4000
 

--- a/backend/irc/ircconnection.ts
+++ b/backend/irc/ircconnection.ts
@@ -38,7 +38,8 @@ scheduleDailyEvent(process.env.LMRD_DUCC_TIME || '09:00', () => {
   setTimeout(() => {
     ircMessageProcessor.sendDuccMessage(DuccMessageTriggerType.KILLERS);
   }, 5000);
-});
+}, process.env.LMRD_DUCC_DAY ? +process.env.LMRD_DUCC_DAY : 0); // Weekday on which to run it
+
 
 client.on('end', () => {
   console.log('disconnected from server');

--- a/backend/tests/cron.test.ts
+++ b/backend/tests/cron.test.ts
@@ -1,0 +1,29 @@
+import { scheduleDailyEvent } from "../utils/cron";
+
+describe('cron scheduling daily events (only the first trigger is checked)', () => {
+  test('trigger function is called at the specified time and day', async () => {
+    const mockCallback = jest.fn(() => console.log('callback called'));
+
+    const date = new Date();
+    scheduleDailyEvent(
+      `${date.getHours()}:${date.getMinutes()}`,
+      mockCallback,
+      date.getDay());
+
+    await new Promise((r) => setTimeout(r, 1000));
+    expect(mockCallback.mock.calls.length).toBe(1);
+  });
+
+  test('trigger function is not called if the day is wrong', async () => {
+    const mockCallback = jest.fn(() => console.log('callback called'));
+
+    const date = new Date();
+    scheduleDailyEvent(
+      `${date.getHours()}:${date.getMinutes()}`,
+      mockCallback,
+      date.getDay() + 1);
+
+    await new Promise((r) => setTimeout(r, 1000));
+    expect(mockCallback.mock.calls.length).toBe(0);
+  });
+});

--- a/backend/utils/cron.ts
+++ b/backend/utils/cron.ts
@@ -4,7 +4,7 @@
  * @param time Hour and minute in the format of hh:mm
  * @param triggerThis callback function
  */
-export function scheduleDailyEvent(time: string | undefined, triggerThis: () => void): void {
+export function scheduleDailyEvent(time: string | undefined, triggerThis: () => void, weekday?: number): void {
   if (time === undefined || !time.match(/^\d\d:\d\d$/)) {
     console.warn('Please specify a time string in the format of hh:mm');
     return;
@@ -29,7 +29,22 @@ export function scheduleDailyEvent(time: string | undefined, triggerThis: () => 
   // trigger the function triggerThis() at the timepoint
   // create setInterval when the timepoint is reached to trigger it every day at this timepoint
   setTimeout(function () {
-    triggerThis();
-    setInterval(triggerThis, 24 * 60 * 60 * 1000);
+    triggerFunctionIfWeekday(triggerThis, weekday);
+    setInterval(() => triggerFunctionIfWeekday(triggerThis, weekday), 24 * 60 * 60 * 1000);
   }, firstTriggerAfterMs);
+}
+
+function triggerFunctionIfWeekday(triggerThis: () => void, weekday?: number): void {
+  // Do on each day if weekday is undefined
+  if (!weekday) {
+    triggerThis();
+    return;
+  }
+
+  // Only do on a specific weekday
+  const currentDayNumber = new Date().getDay();
+  if (currentDayNumber !== weekday) {
+    return;
+  }
+  triggerThis();
 }

--- a/frontend/components/DuccStatsList.tsx
+++ b/frontend/components/DuccStatsList.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import eventSource from '../data/EventSource';
 import DuccStat, { IDuccStat } from './DuccStat';
+import { Tooltip } from 'reactstrap';
 
 export default function DuccStatsList(props: IProps) {
   const [fetchedStats, setFetchedStats] = useState<IDuccStat[]>([{ user: 'Loading...' }]);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
 
   useEffect(() => {
     eventSource.onmessage = (e) => {
@@ -16,10 +18,15 @@ export default function DuccStatsList(props: IProps) {
     });
   }, []);
 
+  const toggle = () => setTooltipOpen(!tooltipOpen);
+
   return (
     <div>
-      <div className={'duccstatslist-header'}>
-        Top Ducc {props.type === ScoreType.FRIENDS ? 'Friends' : 'Killers'}:{' '}
+      <div>
+        <p className={'duccstatslist-header'}>Top Ducc {props.type === ScoreType.FRIENDS ? 'Friends' : 'Killers'}: <span className={'duccstatslist-tooltip'} id="duccstatslist-tooltip">?</span></p>
+        <Tooltip placement="right" isOpen={tooltipOpen} target="duccstatslist-tooltip" toggle={toggle}>
+          Generated weekly
+        </Tooltip>
       </div>
       <div className={'duccstatslist-content'}>
         {fetchedStats.map((duccStat) => (

--- a/frontend/styles/DuccStatsList.scss
+++ b/frontend/styles/DuccStatsList.scss
@@ -1,6 +1,12 @@
 .duccstatslist-header {
   font-weight: bold;
   text-align: center;
+  margin-bottom: 0;
+
+  .duccstatslist-tooltip {
+    font-weight: normal !important;
+    opacity: 50%;
+  }
 }
 .duccstatslist-content {
   text-align: center;

--- a/frontend/styles/TopWords.scss
+++ b/frontend/styles/TopWords.scss
@@ -1,3 +1,0 @@
-.topwords-header {
-  font-weight: bold;
-}

--- a/frontend/styles/all.scss
+++ b/frontend/styles/all.scss
@@ -5,7 +5,6 @@
 @use 'UserList';
 @use 'Message';
 @use 'MessageList';
-@use 'TopWords';
 @use 'NickColors';
 @use 'DuccStatsList';
 @use 'Srcery';


### PR DESCRIPTION
A minority of users who are on Matrix/Element get unnecessary notifications because their client does not suppress them even if the nick contains zero-width spaces (https://github.com/vector-im/element-web/issues/16659), as it does when .fr and .kille is called.

Therefore, to reduce spam for them, the ducc command is now sent only once a week, instead of daily.

The weekday is configurable via the `LMRD_DUCC_DAY` environment variable (numbering equivalent to [`getDay`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay))