### PR TITLE
top word calculations hourly and pull from db

### DIFF
--- a/backend/Sender.ts
+++ b/backend/Sender.ts
@@ -1,7 +1,5 @@
 import { Response } from 'express-serve-static-core';
-import sw from 'stopword';
-import stopwordsEn from 'stopwords-en';
-import { DatabaseMessageUtils, IMessage } from './database/Messages';
+import { DatabaseMessageUtils } from './database/Messages';
 import { DatabaseUserUtils } from './database/Users';
 import { DatabaseDuccUtils } from './database/DuccScores';
 import { LogWrapper } from './utils/logging/LogWrapper';
@@ -53,32 +51,6 @@ class Sender {
     }
   }
 
-  static async getTopWords(): Promise<void> {
-    const messages: IMessage[] = await DatabaseMessageUtils.getLinesLastNDays(7);
-    const wordCounts: Map<string, number> = new Map<string, number>();
-
-    for (const message of messages) {
-      const messageText: string = message.message.toLowerCase();
-
-      const splitAndCleanedWords: string[] = messageText
-        .split(/\s+/)
-        .map((word: string) => word.replace(/[^a-zA-Z0-9 ]/g, '').trim());
-
-      // More stop word sources are necessary to filter out all
-      const words = sw.removeStopwords(splitAndCleanedWords, [...sw.en, ...stopwordsEn]);
-
-      for (const word of words) {
-        if (word && !word.match(/^[0-9]*$/)) {
-          if (!wordCounts.has(word)) wordCounts.set(word, 1);
-          else wordCounts.set(word, wordCounts.get(word)! + 1);
-        }
-      }
-    }
-
-    const sortedWordCounts: Map<string, number> = new Map([...wordCounts.entries()].sort((a, b) => b[1] - a[1]));
-    await DatabaseMessageUtils.insertTopWords(sortedWordCounts);
-  }
-
   static async sendTopWords(res: Response<any, number>): Promise<void> {
     if (res) {
       log.debug('Sending top words to', { ip: res.req?.ip });
@@ -98,11 +70,5 @@ class Sender {
     }
   }
 }
-
-// every hour we do the top words calculation
-setInterval(() => {
-  log.info('Running top words calculation and inserting into DB');
-  Sender.getTopWords();
-}, 1000 * 60 * 60);
 
 export { Sender };

--- a/backend/database/Messages.ts
+++ b/backend/database/Messages.ts
@@ -2,6 +2,8 @@ import dotenv from 'dotenv';
 import { LogWrapper } from '../utils/logging/LogWrapper';
 dotenv.config();
 import knex from './dbConn';
+import sw from 'stopword';
+import stopwordsEn from 'stopwords-en';
 
 const log = new LogWrapper(module.id);
 
@@ -102,6 +104,7 @@ class DatabaseMessageUtils {
   }
 
   static async insertTopWords(wordMap: Map<string, number>): Promise<void> {
+    log.debug('Inserting top words into the database');
     wordMap.forEach(async (count, word) => {
       const wordExists = await knex('top_words').select().where({ word });
       if (wordExists.length < 1) {
@@ -113,6 +116,7 @@ class DatabaseMessageUtils {
   }
 
   static async getTopWords(): Promise<ITopWord[]> {
+    log.debug('Retrieving top words from the database');
     const topWords = await knex('top_words').select().orderBy('count', 'desc').limit(20);
     const parsedTopWords = topWords.map((entry) => {
       return {
@@ -121,6 +125,39 @@ class DatabaseMessageUtils {
       };
     });
     return parsedTopWords;
+  }
+
+  static async getTopWordsAndInsertIntoDatabase(): Promise<void> {
+    const sortedWordCounts: Map<string, number> = await DatabaseMessageUtils.calculateTopWords();
+    await DatabaseMessageUtils.insertTopWords(sortedWordCounts);
+  }
+
+  static async calculateTopWords(): Promise<Map<string, number>> {
+    log.debug('Calculating top words');
+    const messages: IMessage[] = await DatabaseMessageUtils.getLinesLastNDays(7);
+    const wordCounts: Map<string, number> = new Map<string, number>();
+
+    for (const message of messages) {
+      const messageText: string = message.message.toLowerCase();
+
+      const splitAndCleanedWords: string[] = messageText
+        .split(/\s+/)
+        .map((word: string) => word.replace(/[^a-zA-Z0-9 ]/g, '').trim());
+
+      // More stop word sources are necessary to filter out all
+      const words = sw.removeStopwords(splitAndCleanedWords, [...sw.en, ...stopwordsEn]);
+
+      for (const word of words) {
+        if (word && !word.match(/^[0-9]*$/)) {
+          if (!wordCounts.has(word)) wordCounts.set(word, 1);
+          else wordCounts.set(word, wordCounts.get(word)! + 1);
+        }
+      }
+    }
+
+    const sortedWordCounts: Map<string, number> = new Map([...wordCounts.entries()].sort((a, b) => b[1] - a[1]));
+    log.debug('Calculating top done');
+    return sortedWordCounts;
   }
 }
 

--- a/backend/database/Messages.ts
+++ b/backend/database/Messages.ts
@@ -98,7 +98,29 @@ class DatabaseMessageUtils {
       }
     }
 
-    log.debug('Saving message to db.', {nick, userIsBot, message});
+    log.debug('Saving message to db.', { nick, userIsBot, message });
+  }
+
+  static async insertTopWords(wordMap: Map<string, number>): Promise<void> {
+    wordMap.forEach(async (count, word) => {
+      const wordExists = await knex('top_words').select().where({ word });
+      if (wordExists.length < 1) {
+        await knex('top_words').insert({ count, word });
+      } else {
+        await knex('top_words').where({ word }).update({ count });
+      }
+    });
+  }
+
+  static async getTopWords(): Promise<ITopWord[]> {
+    const topWords = await knex('top_words').select().orderBy('count', 'desc').limit(20);
+    const parsedTopWords = topWords.map((entry) => {
+      return {
+        word: entry['word'],
+        count: entry['count'],
+      };
+    });
+    return parsedTopWords;
   }
 }
 
@@ -108,6 +130,11 @@ interface ILineCount {
   date: string;
   lineCount: number;
   botLines: number;
+}
+
+interface ITopWord {
+  word: string;
+  count: number;
 }
 
 export interface IMessage {

--- a/backend/database/Messages.ts
+++ b/backend/database/Messages.ts
@@ -133,7 +133,6 @@ class DatabaseMessageUtils {
   }
 
   static async calculateTopWords(): Promise<Map<string, number>> {
-    log.debug('Calculating top words');
     const messages: IMessage[] = await DatabaseMessageUtils.getLinesLastNDays(7);
     const wordCounts: Map<string, number> = new Map<string, number>();
 
@@ -156,7 +155,6 @@ class DatabaseMessageUtils {
     }
 
     const sortedWordCounts: Map<string, number> = new Map([...wordCounts.entries()].sort((a, b) => b[1] - a[1]));
-    log.debug('Calculating top done');
     return sortedWordCounts;
   }
 }

--- a/backend/database/knex_migrations/20210401111901_top_words.ts
+++ b/backend/database/knex_migrations/20210401111901_top_words.ts
@@ -1,0 +1,12 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('top_words', function (table) {
+    table.string('word').unique();
+    table.integer('count');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('top_words');
+}

--- a/backend/irc/ircconnection.ts
+++ b/backend/irc/ircconnection.ts
@@ -35,14 +35,17 @@ rl.on('line', async (line: string) => {
 });
 
 // Daily at 01:00-03:00 CST is best according to aboft => 08:00-10:00 GMT+1 (Server time dependent)
-scheduleDailyEvent(process.env.LMRD_DUCC_TIME || '09:00', () => {
-  log.info(`Sending ducc message at ${new Date().toLocaleTimeString('en')}`);
-  ircMessageProcessor.sendDuccMessage(DuccMessageTriggerType.FRIENDS);
-  setTimeout(() => {
-    ircMessageProcessor.sendDuccMessage(DuccMessageTriggerType.KILLERS);
-  }, 5000);
-}, process.env.LMRD_DUCC_DAY ? +process.env.LMRD_DUCC_DAY : 0); // Weekday on which to run it
-
+scheduleDailyEvent(
+  process.env.LMRD_DUCC_TIME || '12:08',
+  () => {
+    log.info(`Sending ducc message at ${new Date().toLocaleTimeString('en')}`);
+    ircMessageProcessor.sendDuccMessage(DuccMessageTriggerType.FRIENDS);
+    setTimeout(() => {
+      ircMessageProcessor.sendDuccMessage(DuccMessageTriggerType.KILLERS);
+    }, 5000);
+  },
+  process.env.LMRD_DUCC_DAY ? +process.env.LMRD_DUCC_DAY : 0
+); // Weekday on which to run it
 
 client.on('end', () => {
   log.info('disconnected from server');

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "pretty": "prettier --write .",
     "start": "ts-node --transpile-only server",
     "test:unit-local": "JEST_JUNIT_OUTPUT_DIR=results yarn run jest --forceExit",
-    "test:unit-ci": "yarn run jest --forceExit --silent --ci"
+    "test:unit-ci": "yarn run jest --forceExit --ci"
   },
   "dependencies": {
     "@types/collections": "^5.0.2",

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -19,7 +19,7 @@ const resCollection = ResCollection.Instance;
 
 app.get('/healthz', async (req, res, next) => {
   log.info('Got request for /healthz endoint');
-  log.debug('From', {ip: req.ip});
+  log.debug('From', { ip: req.ip });
   ['/health', '/healthz'].indexOf(req.path.toLowerCase()) >= 0 && ['get', 'head'].indexOf(req.method.toLowerCase()) >= 0
     ? res.status(200).end()
     : next();
@@ -27,7 +27,7 @@ app.get('/healthz', async (req, res, next) => {
 
 app.get('/test', async (req, res: Response<any, number>) => {
   log.info('Got request for /test endoint');
-  log.debug('From', {ip: req.ip})
+  log.debug('From', { ip: req.ip });
   const resId = uuidv4();
   resCollection.addToCollection(resId, res);
 
@@ -46,7 +46,7 @@ app.get('/test', async (req, res: Response<any, number>) => {
   await Sender.sendMessages(res);
   await Sender.sendLineCountsLastDays(res);
   await Sender.sendLineCountsHighScores(res);
-  // await Sender.sendTopWords(res);
+  await Sender.sendTopWords(res);
   await Sender.sendDuccScores(res);
 
   // Daily
@@ -56,7 +56,7 @@ app.get('/test', async (req, res: Response<any, number>) => {
 
   req.on('close', () => {
     log.info('connection CLOSED');
-    log.debug('Request IP', {ip: req.ip})
+    log.debug('Request IP', { ip: req.ip });
     resCollection.removeFromCollection(resId);
   });
 });

--- a/backend/tests/DataBaseMessageUtils.test.ts
+++ b/backend/tests/DataBaseMessageUtils.test.ts
@@ -1,7 +1,6 @@
 import mockDb from 'mock-knex';
 import last_messages from './resources/mock_db_data/last_messages.json';
 import { DatabaseMessageUtils } from '../database/Messages';
-import { Sender } from '../Sender';
 import knex from '../database/dbConn';
 import sw from 'stopword';
 import stopwordsEn from 'stopwords-en';
@@ -51,7 +50,7 @@ describe('test Sender with mocked database response', () => {
       query.response(LAST_MESSAGES);
     });
 
-    const sortedWordCounts = await Sender.getTopWords();
+    const sortedWordCounts = await DatabaseMessageUtils.calculateTopWords();
     const expected: Map<string, number> = new Map();
     // Stop words are removed
     expected.set('linux', 3);

--- a/backend/tests/DataBaseMessageUtils.test.ts
+++ b/backend/tests/DataBaseMessageUtils.test.ts
@@ -9,7 +9,7 @@ const tracker = require('mock-knex').getTracker();
 
 let LAST_MESSAGES: { user: string; server: string; message: string; dateCreated: Date | string }[] = [];
 
-describe('test Sender with mocked database response', () => {
+describe('test getLinesLastNDays with mocked database response', () => {
   beforeAll((done) => {
     LAST_MESSAGES = last_messages;
     LAST_MESSAGES.forEach((lm, idx) => {

--- a/frontend/components/TopWordList.tsx
+++ b/frontend/components/TopWordList.tsx
@@ -4,8 +4,8 @@ import TopWord from './TopWord';
 export default function TopWordsList(props: IProps) {
   return (
     <>
-      {Array.from(props.topWords).map((topWord, index) => (
-        <TopWord key={topWord[0].concat(index.toString())} word={topWord[0]} count={topWord[1]} />
+      {props.topWords.map((topWord, index) => (
+        <TopWord key={index.toString()} word={topWord.word} count={topWord.count} />
       ))}
     </>
   );

--- a/frontend/components/TopWords.tsx
+++ b/frontend/components/TopWords.tsx
@@ -23,9 +23,7 @@ export default function TopWords() {
       <Container fluid={'nogutters'}>
         <Row>
           <Col md={6}>
-            <TopWordsList
-              topWords={fetchedTopWords.slice(0, Math.floor(fetchedTopWords.length / 2))}
-            />
+            <TopWordsList topWords={fetchedTopWords.slice(0, Math.floor(fetchedTopWords.length / 2))} />
           </Col>
           <Col md={6}>
             <TopWordsList
@@ -38,4 +36,7 @@ export default function TopWords() {
   );
 }
 
-export type TTopWord = [string, number];
+export type TTopWord = {
+  word: string;
+  count: number;
+};


### PR DESCRIPTION
Top Words are now being run hourly from backend start up time. This now inserts into the database and when a new page is loaded it pulls data only from database. This should prevent the calculations taking too many resources when requests are being processed.