### PR TITLE
Check if weekday is unset differently

### DIFF
--- a/backend/utils/cron.ts
+++ b/backend/utils/cron.ts
@@ -35,8 +35,8 @@ export function scheduleDailyEvent(time: string | undefined, triggerThis: () => 
 }
 
 function triggerFunctionIfWeekday(triggerThis: () => void, weekday?: number): void {
-  // Do on each day if weekday is undefined
-  if (!weekday) {
+  // Do on each day if weekday is not set
+  if (weekday == null) {
     triggerThis();
     return;
   }


### PR DESCRIPTION
Previously this check returned true if weekday was set to 0, which is
the default and also currently used value via the environment, therefore
always triggering the function daily instead of weekly.