### PR TITLE
Fight stats

### DIFF
--- a/backend/Listener.ts
+++ b/backend/Listener.ts
@@ -33,6 +33,10 @@ class Listener {
       log.debug('Received killedScore from emitter, sending ducc scores');
       resCollection.doForAllResInCollection(Sender.sendDuccScores);
     });
+    myEmitter.on('fightScore', async () => {
+      log.debug('Received fightScore from emitter, sending fight scores');
+      resCollection.doForAllResInCollection(Sender.sendFightScores);
+    });
   }
 }
 

--- a/backend/Sender.ts
+++ b/backend/Sender.ts
@@ -3,6 +3,7 @@ import { DatabaseMessageUtils } from './database/Messages';
 import { DatabaseUserUtils } from './database/Users';
 import { DatabaseDuccUtils } from './database/DuccScores';
 import { LogWrapper } from './utils/logging/LogWrapper';
+import { DatabaseFightUtils } from './database/Fights';
 
 const log = new LogWrapper(module.id);
 
@@ -66,6 +67,15 @@ class Sender {
       const duccScores = await DatabaseDuccUtils.retrieveAllDuccScores();
       res.write('event: duccScore\n');
       res.write(`data: ${JSON.stringify({ duccScores })}`);
+      res.write('\n\n');
+    }
+  }
+  static async sendFightScores(res: Response<any, number>): Promise<void> {
+    if (res) {
+      log.debug('Sending fight scores');
+      const topWinnersAndLosers = await DatabaseFightUtils.retrieveTopFightScores();
+      res.write('event: topWinnersAndLosers\n');
+      res.write(`data: ${JSON.stringify({ topWinnersAndLosers })}`);
       res.write('\n\n');
     }
   }

--- a/backend/database/Fights.ts
+++ b/backend/database/Fights.ts
@@ -43,6 +43,31 @@ class DatabaseFightUtils {
           }
         });
   }
+
+  static async retrieveTopFightScores(): Promise<TopWinnerAndLosers> {
+    const topWinnersDb = await knex('fight_scores').select().orderBy('wins', 'desc').limit(10);
+    const topLosersDb = await knex('fight_scores').select().orderBy('losses', 'desc').limit(10);
+
+    const topWinners = topWinnersDb.map((entry) => {
+      return { user: entry['user'], wins: entry['wins'], losses: entry['losses'] };
+    });
+    const topLosers = topLosersDb.map((entry) => {
+      return { user: entry['user'], wins: entry['wins'], losses: entry['losses'] };
+    });
+
+    return { topWinners, topLosers };
+  }
+}
+
+interface FightScore {
+  user: string;
+  wins: number;
+  losses: number;
+}
+
+interface TopWinnerAndLosers {
+  topWinners: FightScore[];
+  topLosers: FightScore[];
 }
 
 export { DatabaseFightUtils };

--- a/backend/database/Fights.ts
+++ b/backend/database/Fights.ts
@@ -1,0 +1,48 @@
+import {FightMsgParseResult} from '../irc/IrcMessageProcessor';
+import {LogWrapper} from '../utils/logging/LogWrapper';
+import knex from './dbConn';
+
+const log = new LogWrapper(module.id);
+
+class DatabaseFightUtils {
+  static async insertOrUpdateFightScores(fightResult: FightMsgParseResult): Promise<void> {
+    if (!fightResult.valid) {
+      log.error('Invalid fight result passed to insertOrUpdateFightScores');
+      return;
+    }
+
+    const tableName = 'fight_scores';
+
+    // Insert or update winner
+    await knex(tableName)
+        .select()
+        .where({user : fightResult.winner})
+        .then(async (rows) => {
+          if (rows.length === 0) {
+            await knex(tableName).insert(
+                {user : fightResult.winner, wins : 1, losses : 0});
+          } else {
+            await knex(tableName)
+                .where({user : fightResult.winner})
+                .increment('wins', 1);
+          }
+        });
+
+    // Insert or update loser
+    await knex(tableName)
+        .select()
+        .where({user : fightResult.loser})
+        .then(async (rows) => {
+          if (rows.length === 0) {
+            await knex(tableName).insert(
+                {user : fightResult.loser, wins : 0, losses : 1});
+          } else {
+            await knex(tableName)
+                .where({user : fightResult.loser})
+                .increment('losses', 1);
+          }
+        });
+  }
+}
+
+export { DatabaseFightUtils };

--- a/backend/database/Fights.ts
+++ b/backend/database/Fights.ts
@@ -44,6 +44,30 @@ class DatabaseFightUtils {
         });
   }
 
+  static async insertOrUpdateFightScoresRelations(fightResult: FightMsgParseResult): Promise<void> {
+    if (!fightResult.valid) {
+      log.error('Invalid fight result passed to insertOrUpdateFightScores');
+      return;
+    }
+
+    const tableName = 'fight_scores_relations';
+
+    // Insert or update relation
+    await knex(tableName)
+        .select()
+        .where({winner : fightResult.winner, loser: fightResult.loser})
+        .then(async (rows) => {
+          if (rows.length === 0) {
+            await knex(tableName).insert(
+                {winner : fightResult.winner, loser : fightResult.loser, times : 1});
+          } else {
+            await knex(tableName)
+                .where({winner : fightResult.winner, loser: fightResult.loser})
+                .increment('times', 1);
+          }
+        });
+  }
+
   static async retrieveTopFightScores(): Promise<TopWinnerAndLosers> {
     const topWinnersDb = await knex('fight_scores').select().orderBy('wins', 'desc').limit(10);
     const topLosersDb = await knex('fight_scores').select().orderBy('losses', 'desc').limit(10);

--- a/backend/database/knex_migrations/20210531140419_fight_scores.ts
+++ b/backend/database/knex_migrations/20210531140419_fight_scores.ts
@@ -1,0 +1,13 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('fight_scores', function(table) {
+    table.string('user').unique();
+    table.integer('wins');
+    table.integer('losses');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('fight_scores');
+}

--- a/backend/database/knex_migrations/20210531160525_fight_scores_relations.ts
+++ b/backend/database/knex_migrations/20210531160525_fight_scores_relations.ts
@@ -1,0 +1,13 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('fight_scores_relations', function(table) {
+    table.string('winner');
+    table.string('loser');
+    table.integer('times');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('fight_scores_relations');
+}

--- a/backend/irc/IrcMessageProcessor.ts
+++ b/backend/irc/IrcMessageProcessor.ts
@@ -213,7 +213,7 @@ class IrcMessageProcessor {
       myEmitter.emit('line');
       // Process bot messages
       // Process ducc stats
-      if (msg.match(/Duck \w{6} scores in #/i) && nick === 'gonzobot') {
+      if (nick === 'gonzobot' && IrcMessageProcessor.matchesDuccMsg(msg)) {
         const duccMsg = ircMessage.params[1];
         const splitMsgByBullet = duccMsg.split('\u2022');
 
@@ -229,7 +229,28 @@ class IrcMessageProcessor {
           myEmitter.emit('killedScore');
         }
       }
+      // Process fight messages
+      const fightMsgParseResult = IrcMessageProcessor.matchesFightMsg(msg);
+      if (nick === 'gonzobot' && fightMsgParseResult.valid) {
+        // TODO
+        console.log("TODO");
+        console.log(fightMsgParseResult.winner);
+        console.log(fightMsgParseResult.loser);
+      }
     }
+  }
+
+  private static matchesDuccMsg(s: string): boolean {
+    return /Duck \w{6} scores in #/i.test(s);
+  }
+
+  public static matchesFightMsg(s: string): FightMsgParseResult {
+    // Thanks audron for the beautiful regex
+    const match = /(?:\w+! ){3}(?<winner>\w+) (?:\w+ ){1,2}over (?<loser>\w+) with (?:\w+[ .]){1,4}/.exec(s);
+    if (match == null) {
+      return {valid : false};
+    }
+    return {valid : true, winner : match.groups!.winner, loser : match.groups!.loser};
   }
 
   private sendPrivMessage(message: string) {
@@ -265,12 +286,20 @@ type PossibleIrcCommand =
   | 'NICK'
   | '900'
   | 'NOTICE';
+
 type DuccMessageTrigger =
   | DuccMessageTriggerType.FRIENDS
   | DuccMessageTriggerType.KILLERS
   | DuccMessageTriggerType.REMINDER;
+
 export enum DuccMessageTriggerType {
   FRIENDS = 'fr',
   KILLERS = 'kille',
   REMINDER = 'reminder',
+}
+
+export interface FightMsgParseResult {
+  valid: boolean;
+  winner?: string;
+  loser?: string;
 }

--- a/backend/irc/IrcMessageProcessor.ts
+++ b/backend/irc/IrcMessageProcessor.ts
@@ -236,7 +236,7 @@ class IrcMessageProcessor {
         if (fightMsgParseResult.valid) {
           await DatabaseFightUtils.insertOrUpdateFightScores(fightMsgParseResult);
           log.debug("Fight parse result", {fightMsgParseResult});
-          // TODO: Send to frontend
+          myEmitter.emit('fightScore');
         }
       }
     }

--- a/backend/irc/IrcMessageProcessor.ts
+++ b/backend/irc/IrcMessageProcessor.ts
@@ -5,6 +5,7 @@ import { DatabaseMessageUtils } from '../database/Messages';
 import { DatabaseUserUtils } from '../database/Users';
 import myEmitter from './utils/emitter';
 import { LogWrapper } from '../utils/logging/LogWrapper';
+import { DatabaseFightUtils } from '../database/Fights';
 
 const log = new LogWrapper(module.id);
 
@@ -233,10 +234,9 @@ class IrcMessageProcessor {
         // Process fight messages
         const fightMsgParseResult = IrcMessageProcessor.matchesFightMsg(msg);
         if (fightMsgParseResult.valid) {
-          // TODO
-          console.log("TODO");
-          console.log(fightMsgParseResult.winner);
-          console.log(fightMsgParseResult.loser);
+          await DatabaseFightUtils.insertOrUpdateFightScores(fightMsgParseResult);
+          log.debug("Fight parse result", {fightMsgParseResult});
+          // TODO: Send to frontend
         }
       }
     }
@@ -247,8 +247,8 @@ class IrcMessageProcessor {
   }
 
   public static matchesFightMsg(s: string): FightMsgParseResult {
-    // Thanks audron for the beautiful regex
-    const match = /(?:\w+! ){3}(?<winner>\w+) (?:\w+ ){1,2}over (?<loser>\w+) with (?:\w+[ .]){1,4}/.exec(s);
+    // Thanks audron for the beautiful initial regex
+    const match = /(?:\w+! ){3}(?<winner>\w+) (?:\w+ ){1,3}over (?<loser>\w+) with (?:\w+[ .]){1,4}/.exec(s);
     if (match == null) {
       return {valid : false};
     }

--- a/backend/irc/IrcMessageProcessor.ts
+++ b/backend/irc/IrcMessageProcessor.ts
@@ -213,29 +213,31 @@ class IrcMessageProcessor {
       myEmitter.emit('line');
       // Process bot messages
       // Process ducc stats
-      if (nick === 'gonzobot' && IrcMessageProcessor.matchesDuccMsg(msg)) {
-        const duccMsg = ircMessage.params[1];
-        const splitMsgByBullet = duccMsg.split('\u2022');
+      if (nick === 'gonzobot') {
+        if (IrcMessageProcessor.matchesDuccMsg(msg)) {
+          const duccMsg = ircMessage.params[1];
+          const splitMsgByBullet = duccMsg.split('\u2022');
 
-        // fix the first split by removing the 'Duck ... scores in #channel'
-        const correctFirstScore = splitMsgByBullet[0].split(':');
-        splitMsgByBullet[0] = `${correctFirstScore[1]}: ${correctFirstScore[2].trim()}`;
+          // fix the first split by removing the 'Duck ... scores in #channel'
+          const correctFirstScore = splitMsgByBullet[0].split(':');
+          splitMsgByBullet[0] = `${correctFirstScore[1]}: ${correctFirstScore[2].trim()}`;
 
-        if (correctFirstScore[0].includes('friend')) {
-          await DatabaseDuccUtils.insertOrUpdateDuccScores(splitMsgByBullet, 'friend');
-          myEmitter.emit('friendScore');
-        } else if (correctFirstScore[0].includes('killer')) {
-          await DatabaseDuccUtils.insertOrUpdateDuccScores(splitMsgByBullet, 'killer');
-          myEmitter.emit('killedScore');
+          if (correctFirstScore[0].includes('friend')) {
+            await DatabaseDuccUtils.insertOrUpdateDuccScores(splitMsgByBullet, 'friend');
+            myEmitter.emit('friendScore');
+          } else if (correctFirstScore[0].includes('killer')) {
+            await DatabaseDuccUtils.insertOrUpdateDuccScores(splitMsgByBullet, 'killer');
+            myEmitter.emit('killedScore');
+          }
         }
-      }
-      // Process fight messages
-      const fightMsgParseResult = IrcMessageProcessor.matchesFightMsg(msg);
-      if (nick === 'gonzobot' && fightMsgParseResult.valid) {
-        // TODO
-        console.log("TODO");
-        console.log(fightMsgParseResult.winner);
-        console.log(fightMsgParseResult.loser);
+        // Process fight messages
+        const fightMsgParseResult = IrcMessageProcessor.matchesFightMsg(msg);
+        if (fightMsgParseResult.valid) {
+          // TODO
+          console.log("TODO");
+          console.log(fightMsgParseResult.winner);
+          console.log(fightMsgParseResult.loser);
+        }
       }
     }
   }

--- a/backend/irc/IrcMessageProcessor.ts
+++ b/backend/irc/IrcMessageProcessor.ts
@@ -235,6 +235,7 @@ class IrcMessageProcessor {
         const fightMsgParseResult = IrcMessageProcessor.matchesFightMsg(msg);
         if (fightMsgParseResult.valid) {
           await DatabaseFightUtils.insertOrUpdateFightScores(fightMsgParseResult);
+          await DatabaseFightUtils.insertOrUpdateFightScoresRelations(fightMsgParseResult);
           log.debug("Fight parse result", {fightMsgParseResult});
           myEmitter.emit('fightScore');
         }

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -47,6 +47,7 @@ app.get('/test', async (req, res: Response<any, number>) => {
   await Sender.sendLineCountsHighScores(res);
   await Sender.sendTopWords(res); // Retrieved from the database
   await Sender.sendDuccScores(res);
+  await Sender.sendFightScores(res);
 
   // Daily we send the top words that are in the database
   setInterval(async () => {

--- a/backend/tests/fightMessageParsing.test.ts
+++ b/backend/tests/fightMessageParsing.test.ts
@@ -1,0 +1,17 @@
+// https://github.com/TotallyNotRobots/CloudBot/blob/992586301a567a27342f2f87240123821e0b821e/data/attacks/fight.json#L4
+
+import { IrcMessageProcessor } from "../irc/IrcMessageProcessor";
+
+describe('parsing a fight result', () => {
+  test('works for correct message (returns match with winner and loser)', async () => {
+    const msg = 'ZAM! BOOM! BANG! fear stands victorious over Asmodean with a crushing side kick.';
+    const result = IrcMessageProcessor.matchesFightMsg(msg);
+    expect(result).toStrictEqual({valid: true, winner: 'fear', loser: 'Asmodean'});
+  });
+
+  test('works for incorrect message (returns no match)', async () => {
+    const msg = 'some other message by gonzobot';
+    const result = IrcMessageProcessor.matchesFightMsg(msg);
+    expect(result).toStrictEqual({valid: false});
+  });
+});

--- a/backend/tests/fightMessageParsing.test.ts
+++ b/backend/tests/fightMessageParsing.test.ts
@@ -3,10 +3,16 @@
 import { IrcMessageProcessor } from "../irc/IrcMessageProcessor";
 
 describe('parsing a fight result', () => {
-  test('works for correct message (returns match with winner and loser)', async () => {
+  test('works for correct message (returns match with winner and loser) 1', async () => {
     const msg = 'ZAM! BOOM! BANG! fear stands victorious over Asmodean with a crushing side kick.';
     const result = IrcMessageProcessor.matchesFightMsg(msg);
     expect(result).toStrictEqual({valid: true, winner: 'fear', loser: 'Asmodean'});
+  });
+
+  test('works for correct message (returns match with winner and loser) 2', async () => {
+    const msg = 'SLAM! BOOM! POW! someone is the champion over anyone with a fatal haymaker punch.';
+    const result = IrcMessageProcessor.matchesFightMsg(msg);
+    expect(result).toStrictEqual({valid: true, winner: 'someone', loser: 'anyone'});
   });
 
   test('works for incorrect message (returns no match)', async () => {

--- a/frontend/components/Dashboard.tsx
+++ b/frontend/components/Dashboard.tsx
@@ -1,10 +1,12 @@
 import { Col, Container, Row } from 'reactstrap';
 import TerminalDuccStats from './TerminalDuccStats';
+import TerminalFightStats from './TerminalFightStats';
 import TerminalLineCountStats from './TerminalLineCountStats';
 import TerminalMessageList from './TerminalMessageList';
 import TerminalTopWords from './TerminalTopWords';
 import TerminalUserList from './TerminalUserList';
 import Terminal from './Terminal';
+import React from 'react';
 
 export default function Dashboard(): JSX.Element {
   return (
@@ -33,9 +35,16 @@ export default function Dashboard(): JSX.Element {
           </Terminal>
         </Col>
         <Col md={4} className={'dashboard-column-entry'}>
-          <Terminal title={'Ducc Stats'} rowStyle={{ justifyContent: 'center', marginTop: '1em' }}>
-            <TerminalDuccStats />
-          </Terminal>
+          <div className={'dashboard-column-inner-top'}>
+            <Terminal title={'Ducc Stats'} rowStyle={{ justifyContent: 'center', marginTop: '1em' }}>
+              <TerminalDuccStats />
+            </Terminal>
+          </div>
+          <div className={'dashboard-column-inner-bottom'}>
+            <Terminal title={'Fight Stats'} rowStyle={{ justifyContent: 'center', marginTop: '1em' }}>
+              <TerminalFightStats />
+            </Terminal>
+          </div>
         </Col>
       </Row>
     </Container>

--- a/frontend/components/DuccStatsList.tsx
+++ b/frontend/components/DuccStatsList.tsx
@@ -13,7 +13,6 @@ export default function DuccStatsList(props: IProps): JSX.Element {
     };
     eventSource.addEventListener('duccScore', (e: any) => {
       const data = JSON.parse(e.data);
-      console.log(data.duccScores);
       setFetchedStats(data.duccScores[props.type]);
     });
   }, []);

--- a/frontend/components/FightStat.tsx
+++ b/frontend/components/FightStat.tsx
@@ -1,0 +1,17 @@
+import {getNickCSSClass} from '../data/UserHash';
+
+export default function FightStat(props: IFightStat): JSX.Element {
+  return (
+    <div>
+      <span className={getNickCSSClass(props.user.replace(/[^a-zA-Z0-9]/g, ''))}>{props.user}</span>:{' '}
+      {props.wins && props.wins}
+      {props.losses && props.losses}
+    </div>
+  );
+}
+
+export interface IFightScore {
+  user: string;
+  wins?: number;
+  losses?: number;
+}

--- a/frontend/components/FightStat.tsx
+++ b/frontend/components/FightStat.tsx
@@ -1,6 +1,6 @@
 import {getNickCSSClass} from '../data/UserHash';
 
-export default function FightStat(props: IFightStat): JSX.Element {
+export default function FightStat(props: IFightScore): JSX.Element {
   return (
     <div>
       <span className={getNickCSSClass(props.user.replace(/[^a-zA-Z0-9]/g, ''))}>{props.user}</span>:{' '}

--- a/frontend/components/FightStatsList.tsx
+++ b/frontend/components/FightStatsList.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import FightStat, { IFightScore } from './FightStat';
+
+export default function FightStatsList(props: IProps): JSX.Element {
+  return (
+    <div>
+      <div>
+        <p className={'duccstatslist-header'}>Top {props.type}:</p>
+      </div>
+      <div className={'duccstatslist-content'}>
+        {props.type === ScoreType.WINS ?
+          props.topWinners != null ? props.topWinners.map((fightScore) => (
+            <FightStat key={fightScore.user} user={fightScore.user} wins={fightScore.wins} />
+          )) : <p>Loading...</p> : 
+          props.topLosers != null ? props.topLosers.map((fightScore) => (
+            <FightStat key={fightScore.user} user={fightScore.user} losses={fightScore.losses} />
+          )) : <p>Loading...</p>
+        }
+      </div>
+    </div>
+  );
+}
+
+interface IProps {
+  type: ScoreType;
+  topWinners?: IFightScore[];
+  topLosers?: IFightScore[];
+}
+
+export enum ScoreType {
+  WINS = 'Wins',
+  LOSSES = 'Losses',
+}

--- a/frontend/components/FightStatsList.tsx
+++ b/frontend/components/FightStatsList.tsx
@@ -5,9 +5,9 @@ export default function FightStatsList(props: IProps): JSX.Element {
   return (
     <div>
       <div>
-        <p className={'duccstatslist-header'}>Top {props.type}:</p>
+        <p className={'fightstatslist-header'}>Top {props.type}:</p>
       </div>
-      <div className={'duccstatslist-content'}>
+      <div className={'fightstatslist-content'}>
         {props.type === ScoreType.WINS ?
           props.topWinners != null ? props.topWinners.map((fightScore) => (
             <FightStat key={fightScore.user} user={fightScore.user} wins={fightScore.wins} />

--- a/frontend/components/FightStatsList.tsx
+++ b/frontend/components/FightStatsList.tsx
@@ -8,14 +8,15 @@ export default function FightStatsList(props: IProps): JSX.Element {
         <p className={'fightstatslist-header'}>Top {props.type}:</p>
       </div>
       <div className={'fightstatslist-content'}>
-        {props.type === ScoreType.WINS ?
-          props.topWinners != null ? props.topWinners.map((fightScore) => (
-            <FightStat key={fightScore.user} user={fightScore.user} wins={fightScore.wins} />
-          )) : <p>Loading...</p> : 
-          props.topLosers != null ? props.topLosers.map((fightScore) => (
-            <FightStat key={fightScore.user} user={fightScore.user} losses={fightScore.losses} />
-          )) : <p>Loading...</p>
-        }
+        {props.type === ScoreType.WINS
+          ? props.topWinners &&
+            props.topWinners.map((fightScore) => (
+              <FightStat key={fightScore.user} user={fightScore.user} wins={fightScore.wins} />
+            ))
+          : props.topLosers &&
+            props.topLosers.map((fightScore) => (
+              <FightStat key={fightScore.user} user={fightScore.user} losses={fightScore.losses} />
+            ))}
       </div>
     </div>
   );

--- a/frontend/components/TerminalFightStats.tsx
+++ b/frontend/components/TerminalFightStats.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { Col } from 'reactstrap';
+import FightStatsList, { ScoreType } from './FightStatsList';
+import eventSource from '../data/EventSource';
+import { IFightScore } from './FightStat';
+
+export default function Terminal(): JSX.Element {
+  const [fetchedTopWinnersAndLosers, setFetchedTopWinnersAndLosers] = useState<TopWinnersAndLosers>([{ user: 'Loading...' }]);
+
+  useEffect(() => {
+    eventSource.onmessage = (e) => {
+      console.log(e);
+    };
+    eventSource.addEventListener('topWinnersAndLosers', (e: any) => {
+      const data = JSON.parse(e.data);
+      console.log(data.duccScores);
+      setFetchedTopWinnersAndLosers(data.topWinnersAndLosers);
+    });
+  }, []);
+
+  return (
+    <>
+      <Col md={6}>
+        <FightStatsList type={ScoreType.WINS} topWinners={fetchedTopWinnersAndLosers.topWinners} />
+      </Col>
+      <Col md={6}>
+        <FightStatsList type={ScoreType.LOSSES} topLosers={fetchedTopWinnersAndLosers.topLosers} />
+      </Col>
+    </>
+  );
+}
+
+interface TopWinnersAndLosers {
+  topWinners: IFightScore[];
+  topLosers: IFightScore[];
+}
+

--- a/frontend/components/TerminalFightStats.tsx
+++ b/frontend/components/TerminalFightStats.tsx
@@ -5,7 +5,10 @@ import eventSource from '../data/EventSource';
 import { IFightScore } from './FightStat';
 
 export default function Terminal(): JSX.Element {
-  const [fetchedTopWinnersAndLosers, setFetchedTopWinnersAndLosers] = useState<TopWinnersAndLosers>([{ user: 'Loading...' }]);
+  const [fetchedTopWinnersAndLosers, setFetchedTopWinnersAndLosers] = useState<TopWinnersAndLosers>({
+    topWinners: [{ user: 'Loading...' }],
+    topLosers: [{ user: 'Loading...' }],
+  });
 
   useEffect(() => {
     eventSource.onmessage = (e) => {
@@ -13,7 +16,6 @@ export default function Terminal(): JSX.Element {
     };
     eventSource.addEventListener('topWinnersAndLosers', (e: any) => {
       const data = JSON.parse(e.data);
-      console.log(data.duccScores);
       setFetchedTopWinnersAndLosers(data.topWinnersAndLosers);
     });
   }, []);
@@ -34,4 +36,3 @@ interface TopWinnersAndLosers {
   topWinners: IFightScore[];
   topLosers: IFightScore[];
 }
-

--- a/frontend/components/UserList.tsx
+++ b/frontend/components/UserList.tsx
@@ -11,7 +11,6 @@ export default function UserList(): JSX.Element {
     };
     eventSource.addEventListener('users', (e: any) => {
       const data = JSON.parse(e.data);
-      console.log(e);
       setFetchedUsers(data.users);
     });
   }, []);

--- a/frontend/styles/Dashboard.scss
+++ b/frontend/styles/Dashboard.scss
@@ -3,5 +3,13 @@
 
   .dashboard-column-entry {
     padding: 0.5em;
+
+    .dashboard-column-inner-top {
+      padding-bottom: 0.5em;
+    }
+
+    .dashboard-column-inner-bottom {
+      padding-top: 0.5em;
+    }
   }
 }

--- a/frontend/styles/FightStatsList.scss
+++ b/frontend/styles/FightStatsList.scss
@@ -1,14 +1,14 @@
-.duccstatslist-header {
+.fightstatslist-header {
   font-weight: bold;
   text-align: center;
   margin-bottom: 0;
 
-  .duccstatslist-tooltip {
+  .fightstatslist-tooltip {
     font-weight: normal !important;
     opacity: 50%;
   }
 }
 
-.duccstatslist-content {
+.fightstatslist-content {
   text-align: center;
 }

--- a/frontend/styles/all.scss
+++ b/frontend/styles/all.scss
@@ -8,6 +8,7 @@
 @use 'MessageList';
 @use 'NickColors';
 @use 'DuccStatsList';
+@use 'FightStatsList';
 @use 'LineCount';
 @use 'TopWords';
 @use 'TopWord';


### PR DESCRIPTION
On each fight result message sent by gonzobot, the result is saved in the database, once with relation, once for each user.

The stats about wins and losses for each user are sent to the frontend on each change and displayed in a component.

The table that contains relations is as of yet unused, but may be used in the future in the frontend with an input element where site users can select pairings of IRC users.

![2021-05-31_15-43](https://user-images.githubusercontent.com/9076894/120202533-fa5ee180-c226-11eb-9115-906485ab78ae.png)
